### PR TITLE
add services docker-compose file for managing development service dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@
 
 public/uploads
 public/spree/products/*
+
+config/deploy/bin
+config/deploy/db
+config/deploy/tmp

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Things you may want to cover:
 
 * ...
 
+## Development Setup
+
+To start development dependencies, execute:
+
+```
+bin/dev-services -d
+```
+
+To run migrations:
+
+```
+rake db:create && rake db:migrate
+```
 
 # Themes
 

--- a/bin/dev-services
+++ b/bin/dev-services
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f config/deploy/docker-compose.services.dev.yaml ${1-up} ${@:2}

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,16 +3,19 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  username: postgres
 
 development:
   <<: *default
   database: bookstore_development
   pool: <%= ENV['WEB_THREADS'] || 10 %>
+  username: postgres
+  password: postgres
 
 test:
   <<: *default
   database: bookstore_test<%= ENV['TEST_ENV_NUMBER'] %>
+  username: postgres
+  password: postgres
 
 staging:
   <<: *default

--- a/config/deploy/docker-compose.services.dev.yaml
+++ b/config/deploy/docker-compose.services.dev.yaml
@@ -1,0 +1,27 @@
+version: '3'
+
+volumes:
+  # We'll define a volume that will store the data from the postgres databases:
+  postgres-data:
+
+services:
+  # Our PostgreSQL service:
+  postgres:
+    image: postgres:9.6.3
+    ports:
+      # We'll bind our host's port 5432 to postgres's port 5432, so we can use
+      # our database IDEs with it:
+      - 5432:5432
+    volumes:
+      # Mount the DB dumps folder into the container, to be able to create & access database dumps:
+      - ./db/dumps:/db/dumps
+      # Mount out tmp folder, we might want to have access to something there during development:
+      - ./tmp:/tmp
+      # Mount our 'restoredb' script:
+      - ./bin/restoredb:/bin/restoredb:ro
+      # Mount our 'dumpdb' script:
+      - ./bin/dumpdb:/bin/dumpdb:ro
+      # We'll mount the 'postgres-data' volume into the location Postgres stores it's data:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
This will help simplify development workflow by having dependencies managed by docker.

Running the rails app itself and specs would still happen locally outside of the container.

We'll be able to add additional services here as we go such as:

* elasticsearch
* geth (for token integration)
* redis
* memcache

Let me know what you think.